### PR TITLE
I2C->SoftI2C, typos fixed, black formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,17 +1,17 @@
 # micropython_ahtx0
 
-MicroPython driver for the AHT10 and AHT20 temperature and humindity sensors.
+MicroPython driver for the AHT10 and AHT20 temperature and humidity sensors.
 
 ## Example usage
 
 ```python
 import utime
-from machine import Pin, I2C
+from machine import Pin, SoftI2C
 
 import ahtx0
 
 # I2C for the Wemos D1 Mini with ESP8266
-i2c = I2C(scl=Pin(5), sda=Pin(4))
+i2c = SoftI2C(scl=Pin(5), sda=Pin(4))
 
 # Create the sensor object using I2C
 sensor = ahtx0.AHT10(i2c)

--- a/ahtx0.py
+++ b/ahtx0.py
@@ -95,7 +95,7 @@ class AHT10:
 
     def _read_to_buffer(self):
         self._i2c.readfrom_into(self._address, self._buf)
-    
+
     def _trigger_measurement(self):
         """Internal function for triggering the AHT to read temp/humidity"""
         self._buf[0] = self.AHTX0_CMD_TRIGGER
@@ -113,5 +113,5 @@ class AHT10:
         self._read_to_buffer()
 
 
-class AHT20(AHT10): 
+class AHT20(AHT10):
     AHTX0_CMD_INITIALIZE = 0xBE  # Calibration command

--- a/examples/ahtx0_deepsleep.py
+++ b/examples/ahtx0_deepsleep.py
@@ -1,6 +1,14 @@
 import utime
 import network
-from machine import I2C, Pin, RTC, DEEPSLEEP, DEEPSLEEP_RESET, reset_cause, deepsleep
+from machine import (
+    SoftI2C,
+    Pin,
+    RTC,
+    DEEPSLEEP,
+    DEEPSLEEP_RESET,
+    reset_cause,
+    deepsleep,
+)
 from umqtt.simple import MQTTClient
 
 import ahtx0
@@ -20,7 +28,7 @@ rtc.irq(trigger=rtc.ALARM0, wake=DEEPSLEEP)
 
 # check if the device woke from a deep sleep
 if reset_cause() == DEEPSLEEP_RESET:
-    print('woke from a deep sleep')
+    print("woke from a deep sleep")
 
 # set RTC.ALARM0 to fire after 10 seconds (waking the device)
 rtc.alarm(rtc.ALARM0, 10000)

--- a/examples/ahtx0_deepsleep.py
+++ b/examples/ahtx0_deepsleep.py
@@ -14,7 +14,7 @@ from umqtt.simple import MQTTClient
 import ahtx0
 
 # I2C for the Wemos D1 Mini with ESP8266
-i2c = I2C(scl=Pin(5), sda=Pin(4))
+i2c = SoftI2C(scl=Pin(5), sda=Pin(4))
 
 # Create the sensor object using I2C
 sensor = ahtx0.AHT10(i2c)
@@ -44,7 +44,8 @@ if not wlan.isconnected():
     print("wifi connected")
 
 print("establishing mqtt broker connection...")
-c = MQTTClient("umqtt_client", "hostname")
+# needs non-zero keepalive for broker like mosquitto 2.0.12+
+c = MQTTClient("umqtt_client", "hostname", keepalive=1)
 c.connect()
 print("connected to mqtt broker")
 c.publish(b"temp1/temperature", "{:.2f}".format(sensor.temperature))

--- a/examples/ahtx0_simpletest.py
+++ b/examples/ahtx0_simpletest.py
@@ -1,10 +1,10 @@
 import utime
-from machine import Pin, I2C
+from machine import Pin, SoftI2C
 
 import ahtx0
 
 # I2C for the Wemos D1 Mini with ESP8266
-i2c = I2C(scl=Pin(5), sda=Pin(4))
+i2c = SoftI2C(scl=Pin(5), sda=Pin(4))
 
 # Create the sensor object using I2C
 sensor = ahtx0.AHT10(i2c)

--- a/setup.py
+++ b/setup.py
@@ -5,10 +5,10 @@ with open("README.md", "r", encoding="utf-8") as fh:
 
 setuptools.setup(
     name="micropython-ahtx0",
-    version="0.1.0",
+    version="0.2.0",
     author="Andreas Bühl",
     author_email="code@abuehl.de",
-    description="MicroPython driver for the AHT10 and AHT20 temperature and humindity sensors.",
+    description="MicroPython driver for the AHT10 and AHT20 temperature and humidity sensors.",
     long_description=long_description,
     long_description_content_type="text/markdown",
     keywords="aht10, aht20, micropython, temperature, humidity, sensor, i2c",


### PR DESCRIPTION
I've successfully used this with the Adafruit AHT20 StemmaQT/Qwiic board, and an ESP32 running MicroPython 1.18.

In doing so:
- I2C is marked as deprecated in favour of SoftI2C (updated here)
- fixed some typos
- formatted with black
- noticed in manual testing that umqtt.simple may not connect to some brokers due to a change to the connection handshake. My board didn't have the same sleep capabilities so I didn't test all of the deepsleep sample, but was able to use umqtt.robust and set a keepalive value to resolve this (see e.g. https://github.com/micropython/micropython-lib/issues/466 which discusses the problem; I've not fixed it in this PR)